### PR TITLE
Added colors from logo via daisyui

### DIFF
--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -8,6 +8,23 @@ const config = {
 			}
 		}
 	},
+	daisyui: {
+	      themes: [
+		{
+		  mytheme: {
+			"primary": "#FFD700",
+          		"secondary": "#0057B7",
+        		"accent": "#FF6978",
+			"neutral": "#191D24",
+			"base-100": "#2A303C",
+			"info": "#FF6978",
+			"success": "#0057B7",
+			"warning": "#0057B7",
+			"error": "#0057B7",
+		  },
+		},
+	      ],
+	    },
 
 	plugins: [require('daisyui')]
 };


### PR DESCRIPTION
Colors assigned based on what looked most legible on the existing front end, but should be a simple fix if things don't look good once the rest of the front end is built out.
Yellow: #FFD700 
Blue: #0057B7
Ultra Red: #FF6978